### PR TITLE
Try to hide Windows font artefacts

### DIFF
--- a/static/index.css
+++ b/static/index.css
@@ -28,4 +28,5 @@ main h1#countdown {
     font-family: 'DSEG7-Classic';
     font-weight: bold;
     transform: translateX(-8%); /* HACK: Offset so the time is centred, not the whole text */
+    backface-visibility: hidden; /* Makes Windows font rendering bugs less noticeable */
 }


### PR DESCRIPTION
This still doesn't remove the artefacting entirely but makes it occur less often. It still is most visible at the top of characters, see below.
![image](https://github.com/user-attachments/assets/25881646-e1b2-4e6e-9fab-5dd0611ec2ec)
